### PR TITLE
feat: add govuk-global-styles to application.scss

### DIFF
--- a/common/assets/sass/application.scss
+++ b/common/assets/sass/application.scss
@@ -1,3 +1,4 @@
+$govuk-global-styles: true;
 @import "govuk-frontend/all";
 
 @import "components/cookie-message";


### PR DESCRIPTION
Prevents having to add `.govuk-body` to `<p>` tags and `.govuk-link` to `<a>` tags as per [here](https://github.com/alphagov/govuk-frontend/blob/ad596de756ef51619c6e5bc8f22f3b93479773dd/src/core/_global-styles.scss#L9)